### PR TITLE
CI: Move part of the checks from GitLab CI/CD to GitHub actions

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git/*
+ignore-regex = @groupes.epfl.ch
+ignore-words-list = coo

--- a/.github/workflows/check-packaging.yml
+++ b/.github/workflows/check-packaging.yml
@@ -1,0 +1,20 @@
+name: Check packaging
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+jobs:
+  check-packaging:
+    name: Build and check the distribution package
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install test dependencies
+      run: |
+        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install tox-gh-actions
+    - name: Run tox
+      run: |
+        tox -e check-packaging

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Static code analysis
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+jobs:
+  lint:
+    name: Perform static analysis of the code
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install test dependencies
+      run: |
+        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install tox-gh-actions
+    - name: Run tox
+      run: |
+        tox -e lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@ include:
   - project: nse/ci
     file:
     - ci/lib/tox-bb5.yml
-    - ci/jobs/lint.yml
 
 workflow:
   rules:
@@ -22,10 +21,8 @@ default:
   tags: [bb5_map]
 
 stages:
-- .pre
 - build
 - test
-- publish
 
 variables:
   SPACK_PACKAGE: py-multiscale-run
@@ -125,6 +122,3 @@ init_julia_create_test:
   script:
   - spack ${SPACK_EXTRA_FLAGS} load /${SPACK_INSTALLED_HASH}
   - ${SPACK_SOURCE_DIR}/.ci/test_init_julia_create.sh
-
-lint:
-  stage: .pre

--- a/README.md
+++ b/README.md
@@ -136,7 +136,13 @@ For more on how to use ARM MAP on BB5, please check [this page](https://bbpteam.
 
 # Changelog
 
-## 0.8.2 - 2024-??-??
+## 0.8.2 - 2024-08-27
+
+### Project governance
+
+* Open-source release on GitHub https://github.com/BlueBrain/MultiscaleRun
+* Publication of the documentation on https://multiscalerun.rtfd.io
+* Move some of the GitLab CI/CD tasks to GitHub workflows.
 
 ### Bugfixes
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
 [base]
 name = multiscale_run
 
+[tox]
+envlist =
+    check-packaging
+    lint
+    docs
+
 [testenv]
 pass_env = *
 
@@ -12,12 +18,14 @@ commands = sphinx-build -W --keep-going docs docs/build/html
 [testenv:lint]
 skip_install = True
 deps =
+    codespell
     ruff
 commands =
     ruff check {posargs}
     ruff format --check
     # docstring check is not mandatory to pass for now
     - ruff check  --select D --ignore D401,D407,D413 multiscale_run
+    codespell --config .codespellrc -i 3 -w {[base]files} README.md docs/
 
 [testenv:fixlint]
 skip_install = True
@@ -26,3 +34,12 @@ deps =
 commands =
     ruff format
     ruff check {posargs:--fix}
+
+[testenv:check-packaging]
+skip_install = true
+deps =
+    build
+    twine
+commands =
+    python -m build -o {envtmpdir}/dist
+    twine check {envtmpdir}/dist/*


### PR DESCRIPTION
This contribution introduces GitHub Actions to replace some of the tasks previously done by GitLab CI/CD, and prepare the release 0.8.2 to publish it on PyPI.